### PR TITLE
400 status codes should not be considered errors in the context telemetry

### DIFF
--- a/lib/OpenTelemetry/Integration/HTTP/Tiny.pm
+++ b/lib/OpenTelemetry/Integration/HTTP/Tiny.pm
@@ -128,7 +128,7 @@ sub install ( $class, %config ) {
         $span->set_attribute( 'http.response.body.size' => $length )
             if defined $length;
 
-        if ( $res->{success} ) {
+        if ( $res->{status} < 500 ) {
             $span->set_status( SPAN_STATUS_OK );
         }
         elsif ( $res->{status} == 599 ) {

--- a/lib/OpenTelemetry/Integration/LWP/UserAgent.pm
+++ b/lib/OpenTelemetry/Integration/LWP/UserAgent.pm
@@ -128,7 +128,7 @@ sub install ( $class, %config ) {
             $span->set_attribute( 'http.response.body.size' => $length )
                 if defined $length;
 
-            if ( $response->is_success ) {
+            if ( $response->code >= 500 ) {
                 $span->set_status( SPAN_STATUS_OK );
             }
             else {


### PR DESCRIPTION
All codes in the 200-499 range should be considered a success in the context of telemetry.