### PR TITLE
Numify flags in TraceFlags to prevent string serialization

### DIFF
--- a/lib/OpenTelemetry/Propagator/TraceContext/TraceFlags.pm
+++ b/lib/OpenTelemetry/Propagator/TraceContext/TraceFlags.pm
@@ -30,7 +30,7 @@ class OpenTelemetry::Propagator::TraceContext::TraceFlags {
             $flags = 0;
         }
 
-        ( flags => $flags );
+        ( flags => $flags + 0 );
     }
 
     method to_string () { sprintf '%02x', $flags }

--- a/t/OpenTelemetry/Propagator/TraceContext/TraceFlags.t
+++ b/t/OpenTelemetry/Propagator/TraceContext/TraceFlags.t
@@ -23,6 +23,13 @@ no_messages {
         call flags   => 0;
         call sampled => F;
     }, 'Ignores undef';
+
+    # flags must be numeric, not stringified by the regex validation
+    use JSON::PP;
+    is encode_json({ f => CLASS->new(0)->flags }), '{"f":0}',
+        'flags serializes as integer in JSON';
+    is encode_json({ f => CLASS->new->flags }), '{"f":0}',
+        'default flags serializes as integer in JSON';
 };
 
 is messages {


### PR DESCRIPTION
The regex validation in BUILDARGS stringifies $flags as a side effect of the =~ match. This causes flags to serialize as "0" (string) instead of 0 (integer) in JSON output, which breaks the OpenTelemetry::SDK Console exporter tests.